### PR TITLE
Fix Cloudflare Pages build: rename eleventy config .ts → .mjs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,12 @@ npm test             # Playwright integration tests (starts dev server automatic
 
 ## Stack
 
-- **SSG**: Eleventy 3 with TypeScript config (`eleventy.config.ts`)
+- **SSG**: Eleventy 3 (`eleventy.config.mjs`)
 - **Templates**: Nunjucks (`.njk`) for layouts and pages, Markdown for content
 - **Styling**: Plain CSS (`src/css/style.css`) — no framework
 - **Tests**: Playwright (`tests/site.spec.ts`)
 - **Hosting**: Cloudflare Pages (static deploy from `_site/`)
-- **CI/CD**: GitHub Actions — lint/build/test on PRs with preview deploys, auto-deploy on main
+- **CI/CD**: GitHub Actions for lint/test; Cloudflare Pages GitHub integration for deploys
 - **Node**: 22 (see `mise.toml`)
 
 ## Project structure
@@ -59,7 +59,4 @@ src/
 
 ## Deployment
 
-Cloudflare Pages project `samn-biz`. Requires these GitHub secrets:
-
-- `CLOUDFLARE_API_TOKEN`
-- `CLOUDFLARE_ACCOUNT_ID`
+Cloudflare Pages project `samn-biz` with GitHub integration (auto-deploys on push). Custom domain: `www2.samn.biz`.

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -1,10 +1,4 @@
-interface EleventyConfig {
-  addPassthroughCopy(path: string): void
-  addGlobalData(name: string, value: unknown): void
-  addFilter(name: string, fn: (...args: never[]) => unknown): void
-}
-
-export default function (eleventyConfig: EleventyConfig) {
+export default function (eleventyConfig) {
   // Passthrough copy CSS
   eleventyConfig.addPassthroughCopy('src/css')
 
@@ -12,7 +6,7 @@ export default function (eleventyConfig: EleventyConfig) {
   eleventyConfig.addGlobalData('currentYear', new Date().getFullYear())
 
   // Date formatting filter — matches Gatsby's "DD MMMM, YYYY" format
-  eleventyConfig.addFilter('dateFormat', (date: Date) => {
+  eleventyConfig.addFilter('dateFormat', (date) => {
     const d = new Date(date)
     const day = String(d.getUTCDate()).padStart(2, '0')
     const months = [
@@ -35,7 +29,7 @@ export default function (eleventyConfig: EleventyConfig) {
   })
 
   // Excerpt filter — strips HTML and truncates
-  eleventyConfig.addFilter('excerpt', (content: string, length = 200) => {
+  eleventyConfig.addFilter('excerpt', (content, length = 200) => {
     const text = (content ?? '').replace(/<[^>]*>/g, '').trim()
     if (text.length <= length) return text
     return text.substring(0, length).replace(/\s+\S*$/, '') + '\u2026'

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "CC-BY-NC-SA-4.0",
   "type": "module",
   "scripts": {
-    "build": "eleventy --config=eleventy.config.ts",
-    "dev": "eleventy --serve --config=eleventy.config.ts",
+    "build": "eleventy --config=eleventy.config.mjs",
+    "dev": "eleventy --serve --config=eleventy.config.mjs",
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint --fix . && prettier --write .",
     "format": "prettier --write .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   webServer: {
     command:
-      'npx @11ty/eleventy --config=eleventy.config.ts && npx serve _site -l 3737 --no-clipboard',
+      'npx @11ty/eleventy --config=eleventy.config.mjs && npx serve _site -l 3737 --no-clipboard',
     port: 3737,
     reuseExistingServer: !process.env.CI,
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["eleventy.config.ts", "playwright.config.ts", "tests/**/*.ts"]
+  "include": ["playwright.config.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Rename `eleventy.config.ts` → `eleventy.config.mjs` to fix Cloudflare Pages build failure
- Cloudflare's Node 22 doesn't enable `--experimental-strip-types` by default, causing `ERR_UNKNOWN_FILE_EXTENSION` on `.ts` files
- Update all references in `package.json`, `playwright.config.ts`, `tsconfig.json`, and `CLAUDE.md`
- Update CLAUDE.md to reflect Cloudflare Pages GitHub integration for deploys

## Test plan

- [x] `npm run build` passes locally
- [x] `npm run lint` passes
- [x] All 15 Playwright tests pass
- [ ] Cloudflare Pages build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)