### PR TITLE
Update GitHub Actions to use pinned commit hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow to use pinned commit hashes instead of version tags for improved security and reproducibility.

## Key Changes
- Updated `actions/checkout` from `v4` to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- Updated `actions/setup-node` from `v4` to `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0)

## Implementation Details
By pinning to specific commit hashes rather than version tags, this approach:
- Prevents unexpected behavior from tag mutations or force pushes
- Ensures consistent, deterministic workflow execution across all runs
- Improves supply chain security by explicitly controlling which code is executed
- Maintains version clarity through inline comments showing the corresponding version tags

https://claude.ai/code/session_01TUUeQRFEwgo9XKze1ikPoA